### PR TITLE
fix: git exit status 128エラーの修正（曖昧なファイル名の問題）

### DIFF
--- a/internal/executor/real.go
+++ b/internal/executor/real.go
@@ -2,8 +2,11 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 // RealCommandExecutor is the real implementation of CommandExecutor
@@ -22,6 +25,11 @@ func (r *RealCommandExecutor) Execute(name string, args ...string) ([]byte, erro
 	
 	output, err := cmd.Output()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Command failed: %s %s\n", name, strings.Join(args, " "))
+		if stderr.Len() > 0 {
+			fmt.Fprintf(os.Stderr, "[ERROR] stderr: %s\n", stderr.String())
+		}
+		
 		// Return stderr content along with the error
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitErr.Stderr = stderr.Bytes()
@@ -41,6 +49,11 @@ func (r *RealCommandExecutor) ExecuteWithStdin(name string, stdin io.Reader, arg
 	
 	output, err := cmd.Output()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Command failed: %s %s (with stdin)\n", name, strings.Join(args, " "))
+		if stderr.Len() > 0 {
+			fmt.Fprintf(os.Stderr, "[ERROR] stderr: %s\n", stderr.String())
+		}
+		
 		// Return stderr content along with the error
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitErr.Stderr = stderr.Bytes()

--- a/internal/stager/stager.go
+++ b/internal/stager/stager.go
@@ -201,6 +201,10 @@ func (s *Stager) StageHunks(hunkSpecs []string, patchFile string) error {
 		diffOutput, err := s.executor.Execute("git", diffArgs...)
 		
 		if err != nil {
+			errorMsg := s.getStderrFromError(err)
+			if errorMsg != "" {
+				return fmt.Errorf("failed to get current diff: exit status %v - %s", err, errorMsg)
+			}
 			return fmt.Errorf("failed to get current diff: %v", err)
 		}
 		

--- a/internal/stager/stager.go
+++ b/internal/stager/stager.go
@@ -193,7 +193,7 @@ func (s *Stager) StageHunks(hunkSpecs []string, patchFile string) error {
 		}
 		
 		// Build diff command with specific files
-		diffArgs := []string{"diff", "HEAD"}
+		diffArgs := []string{"diff", "HEAD", "--"}
 		for file := range targetFiles {
 			diffArgs = append(diffArgs, file)
 		}

--- a/internal/stager/stager_e2e_test.go
+++ b/internal/stager/stager_e2e_test.go
@@ -1,0 +1,126 @@
+package stager
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/syou6162/git-sequential-stage/internal/executor"
+)
+
+// TestStageHunks_E2E_AmbiguousFilename tests git-sequential-stage with files that have ambiguous names
+func TestStageHunks_E2E_AmbiguousFilename(t *testing.T) {
+	// Skip if dependencies are not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	if _, err := exec.LookPath("filterdiff"); err != nil {
+		t.Skip("filterdiff not found in PATH")
+	}
+
+	testCases := []struct {
+		name     string
+		filename string
+	}{
+		{"file named master", "master"},
+		{"file named main", "main"}, 
+		{"file named HEAD", "HEAD"},
+		{"file with tag-like name", "v1.0.0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir, err := os.MkdirTemp("", "stager_e2e_test_*")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			// Change to temp directory
+			originalDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("Failed to get current dir: %v", err)
+			}
+			if err := os.Chdir(tmpDir); err != nil {
+				t.Fatalf("Failed to change to temp dir: %v", err)
+			}
+			defer os.Chdir(originalDir)
+
+			// Initialize git repo
+			runCommand(t, "git", "init")
+			runCommand(t, "git", "config", "user.email", "test@example.com")
+			runCommand(t, "git", "config", "user.name", "Test User")
+
+			// Create initial commit
+			if err := os.WriteFile("README.md", []byte("initial"), 0644); err != nil {
+				t.Fatalf("Failed to create README: %v", err)
+			}
+			runCommand(t, "git", "add", "README.md")
+			runCommand(t, "git", "commit", "-m", "Initial commit")
+
+			// Create a file with ambiguous name and commit it
+			initialContent := "line 1\nline 2\nline 3\n"
+			if err := os.WriteFile(tc.filename, []byte(initialContent), 0644); err != nil {
+				t.Fatalf("Failed to create file: %v", err)
+			}
+			runCommand(t, "git", "add", tc.filename)
+			runCommand(t, "git", "commit", "-m", "Add file")
+
+			// Modify the file to create a diff
+			modifiedContent := "line 1\nline 2\nline 3\nline 4\n"
+			if err := os.WriteFile(tc.filename, []byte(modifiedContent), 0644); err != nil {
+				t.Fatalf("Failed to modify file: %v", err)
+			}
+
+			// Generate patch file
+			patchFile := "changes.patch"
+			// Note: git diff needs -- to avoid ambiguity when generating the patch
+			output := runCommand(t, "git", "diff", "HEAD", "--", tc.filename)
+			if err := os.WriteFile(patchFile, output, 0644); err != nil {
+				t.Fatalf("Failed to write patch file: %v", err)
+			}
+
+			// Use StageHunks directly to test the fix
+			realExec := executor.NewRealCommandExecutor()
+			s := NewStager(realExec)
+
+			// This is the actual test - StageHunks should handle ambiguous filenames correctly
+			err = s.StageHunks([]string{tc.filename + ":1"}, patchFile)
+			if err != nil {
+				// If error contains "ambiguous argument", our fix didn't work
+				if strings.Contains(err.Error(), "ambiguous argument") {
+					t.Fatalf("StageHunks failed with ambiguous argument error for file '%s': %v\nThis means the -- separator fix is not working", tc.filename, err)
+				}
+				t.Fatalf("StageHunks failed for file '%s': %v", tc.filename, err)
+			}
+
+			// Verify the file was staged correctly
+			statusOutput := string(runCommand(t, "git", "status", "--porcelain"))
+			expectedStatus := "M  " + tc.filename
+			if !strings.Contains(statusOutput, expectedStatus) {
+				t.Errorf("File '%s' was not staged properly.\nExpected: %s\nGot: %s", 
+					tc.filename, expectedStatus, statusOutput)
+			}
+
+			// Verify the correct hunk was staged
+			diffCachedOutput := string(runCommand(t, "git", "diff", "--cached"))
+			if !strings.Contains(diffCachedOutput, "+line 4") {
+				t.Errorf("The correct hunk was not staged for file '%s'", tc.filename)
+			}
+		})
+	}
+}
+
+// runCommand executes a command and returns its output, failing the test if it errors
+func runCommand(t *testing.T, name string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command failed: %s %s\nOutput: %s\nError: %v", 
+			name, strings.Join(args, " "), output, err)
+	}
+	return output
+}


### PR DESCRIPTION
## 概要

ファイル名がGitのブランチ名やタグ名と同じ場合に`git diff HEAD`コマンドが`exit status 128`エラーを返す問題を修正しました。

## 修正が必要になった背景

`/tmp/current_changes.patch`のようなファイルに対して`git-sequential-stage`を実行した際、以下のエラーが発生していました：

```
Error: Failed to stage hunks: failed to get current diff: exit status 128

Troubleshooting tips:
1. Check if the patch file exists and is readable
2. Verify that the hunks haven't already been staged
3. Ensure the patch was generated from the current working tree state
4. Run 'git status' to check the current state
```

調査の結果、`git diff HEAD ファイル名`の形式で、ファイル名が`master`、`main`、`HEAD`などのブランチ名やタグ名と同じ場合、Gitがそれをリビジョンとして解釈しようとして以下のエラーを返すことが判明しました：

```
fatal: ambiguous argument 'master': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

## 変更内容

### 1. コア修正
- `git diff HEAD`コマンドに`--`セパレータを追加し、その後の引数がファイルパスであることを明示的に指定

### 2. エラーログの改善
- エラー発生時に実行したコマンドとstderrの内容を自動的に出力するように改善
- トラブルシューティングを容易にするため、より詳細なエラー情報を提供

### 3. テストの追加
- 実際のGitリポジトリを使用したエンドツーエンドテストを追加
- `master`、`main`、`HEAD`、`v1.0.0`などの曖昧になりうるファイル名で正しく動作することを検証

## 動作確認

統合テストおよびエンドツーエンドテストで動作を確認し、すべてのテストが通過することを確認しました。